### PR TITLE
Fix for issue #77: Load the translation each time 

### DIFF
--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -21,10 +21,8 @@ module Jekyll
   #*****************************************************************************
   Jekyll::Hooks.register :site, :pre_render do |site, payload|
       lang = site.config['lang']
-      unless site.parsed_translations.has_key?(lang)
-        puts "Loading translation from file #{site.source}/_i18n/#{lang}.yml"
-        site.parsed_translations[lang] = YAML.load_file("#{site.source}/_i18n/#{lang}.yml")
-      end
+      puts "Loading translation from file #{site.source}/_i18n/#{lang}.yml"
+      site.parsed_translations[lang] = YAML.load_file("#{site.source}/_i18n/#{lang}.yml")
   end
   Jekyll::Hooks.register :site, :post_render do |site, payload|
     


### PR DESCRIPTION
When reviewing the Site:Pre_render hook, I've noticed the plugin would only load the YAML translation files once then ignoring it. Translation aren't taken into account unless you build again, making the plugin difficult to use with `jekyll serve`.

Unless there is a performance issue (I don't see one using my current fork), I suggest we remove the `unless` condition and **load the YAML file each time on the Site:Pre_render hook**.