### PR TITLE
Updates `site.translations` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,33 @@ or
 {% translate global.english %}
 ```
 
-You can also access translated strings by accessing the `site.translations` hash, this allows you to loop through your translations within Liquid:
+You can also access translated strings by accessing the `site.translations` hash, this allows you to loop through your translations within Liquid using the translated string's index:
 
 ```liquid
-{% for item in site.translations[site.lang]["my_nested_yaml_collection"] %}
+{% for item in site.translations[site.lang].my_nested_yaml_collection %}
     <p>{{ item[0] }} -> {{ item[1] }}</p>
+{% endfor %}
+```
+
+or the translated string's assignment:
+
+```yaml
+my_nested_yaml_collection:
+  -
+    title: First
+    message: Message
+  -
+    title: Second
+    message: Message
+
+```
+
+```liquid
+{% for item in site.translations[site.lang].my_nested_yaml_collection %}
+   <li>
+      <h2>{{ item["title"] }}</h2>
+      <p>{{ item["message"] }}</p>
+   </li>
 {% endfor %}
 ```
 


### PR DESCRIPTION
I noticed that the `site.translations` docs as written throw a type error with `bundle exec jekyll serve`. 

I think it's because `{% for item in site.translations[site.lang]["my_nested_yaml_collection"] %}` needs to be `{% for item in site.translations[site.lang].my_nested_yaml_collection %}`

I made the change, then added the example mentioned in https://github.com/kurtsson/jekyll-multiple-languages-plugin/issues/66#issuecomment-228619301, which also works (thanks @Anthony-Gaudino). 