### PR TITLE
Remove individual fallback logs unless verbose option is set to true

### DIFF
--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -324,8 +324,10 @@ module Jekyll
       if translation.nil? or translation.empty?
          translation = site.parsed_translations[site.config['default_lang']].access(key)
         
-        puts "Missing i18n key: #{lang}:#{key}"
-        puts "Using translation '%s' from default language: %s" %[translation, site.config['default_lang']]
+        if site.config["verbose"]
+          puts "Missing i18n key: #{lang}:#{key}"
+          puts "Using translation '%s' from default language: %s" %[translation, site.config['default_lang']]
+        end
       end
       
       translation


### PR DESCRIPTION
We have big websites with some parts that are not fully translated. 
The default output from jekyll-multiple-languages-plugin is very verbose in that case without any way to configure it.

This is a proposal to include individual fallback warnings only when jekyll's global `verbose` flag is set to true.