### PR TITLE
Option to build default locale in subfolder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp
 example/Gemfile.lock
 example/_site
 .DS_Store
+.jekyll-cache

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ In code, these specific files should be referenced via `baseurl_root`. E.g.
 <link rel="stylesheet" href="{{ "/css/bootstrap.css" | prepend: site.baseurl_root }}"/>
 ```
 
+If you wish to avoid having the default_lang built into the root of your website, use:
+
+```yaml
+default_locale_in_subfolder: true
+```
+
 ### 4.2. Folder structure
 Create a folder called `_i18n` and add sub-folders for each language, using the same names used on the `languages` setting on the `_config.yml`:
 

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,13 @@ task :default => [:test]
 desc "Run HTMLProofer"
 task :test do
   cd "example" do
+    sh "bundle exec jekyll clean"
     sh "bundle exec jekyll build"
     options = { empty_alt_ignore: true, enforce_https: true }
+    HTMLProofer.check_directory("./_site", options).run
+
+    sh "bundle exec jekyll clean"
+    sh "bundle exec jekyll build -c _config.yml,_config_default_locale_in_subfolder.yml"
     HTMLProofer.check_directory("./_site", options).run
   end
 end

--- a/example/_config_default_locale_in_subfolder.yml
+++ b/example/_config_default_locale_in_subfolder.yml
@@ -1,0 +1,1 @@
+default_locale_in_subfolder: true

--- a/example/_includes/post.html
+++ b/example/_includes/post.html
@@ -16,7 +16,7 @@
       <!-- Adds links to other languages on the post -->
       {% for lang in site.languages %}
         {% unless site.lang == lang %}
-          {% if lang == site.default_lang %}
+          {% if lang == site.default_lang and site.default_locale_in_subfolder != true %}
             <a href="{{ site.baseurl_root }}{{ page.url }}" >{% t langs.{{ lang }} %}</a>
           {% else %}
             <a href="{{ site.baseurl_root }}/{{ lang }}{{ page.url }}" >{% t langs.{{ lang }} %}</a>

--- a/example/_layouts/default.html
+++ b/example/_layouts/default.html
@@ -23,7 +23,7 @@
     <div class="site">
       <div class="sidebar" id="sidebar">
         <div class="header">
-          {% if site.lang == "it" %}
+          {% if site.lang == "it" and site.default_locale_in_subfolder != true %}
             <h1 class="title"><a href="{{ site.baseurl_root }}/"><img id="logo" src="/images/logo.png"></a></h1>
           {% else %}
             <h1 class="title"><a href="{{ site.baseurl_root }}/{{ site.lang }}"><img id="logo" src="/images/logo.png"></a></h1>
@@ -64,9 +64,9 @@
         </div>
         {% tf footer.md %}
         <br />
-        <a class="link-it" href="{{ site.baseurl_root }}/">it</a>
-        <a class="link-en" href="{{ site.baseurl_root }}/en">en</a>
-        <a class="link-es" href="{{ site.baseurl_root }}/es">es</a>
+        <a class="link-it" href="{% tl root it %}">it</a>
+        <a class="link-en" href="{% tl root en %}">en</a>
+        <a class="link-es" href="{% tl root es %}">es</a>
       </div>
 
         {{ content }}

--- a/example/index.html
+++ b/example/index.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 title: Home
+
+namespace: root
+permalink: /
 ---
 
 {% assign page = site.posts.first %}

--- a/example/pagination/index.html
+++ b/example/pagination/index.html
@@ -24,7 +24,7 @@ cover:  cover.jpg
       <!-- Adds links to other languages on the post -->
       {% for lang in site.languages %}
         {% unless site.lang == lang %}
-          {% if lang == site.default_lang %}
+          {% if lang == site.default_lang and site.default_locale_in_subfolder != true %}
             <a href="{{ site.baseurl_root }}{{ page.url }}" >{% t langs.{{ lang }} %}</a>
           {% else %}
             <a href="{{ site.baseurl_root }}/{{ lang }}{{ page.url }}" >{% t langs.{{ lang }} %}</a>


### PR DESCRIPTION
We've been using this plugin for a while with a special setup where the default locale is not mounted at the root of the site but it is in its own subfolder.

It is heavily inspired from @klaasnotfound's comment in #86.

You can enable the behavior by setting `default_locale_in_subfolder` to `true` in _config.yml. I have also updated a little bit the examples to make them compatible with both behaviors.