### PR TITLE
fix `jekyll doctor`

### DIFF
--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -243,9 +243,11 @@ module Jekyll
       
       if site.config['relative_permalinks']
         File.join(@dir,  data['permalink'])
-      else
+      elsif site.config['lang']
         # Look if there's a permalink overwrite specified for this lang
-        data['permalink_'+site.config['lang']] || data['permalink']
+        data['permalink_' + site.config['lang']] || data['permalink']
+      else
+        data['permalink']
       end
       
     end


### PR DESCRIPTION
The gem `jekyll-multiple-languages-plugin` caused an issue when running `jekyll doctor` because `site.config['lang']` wasn't defined yet in my case and therefore caused an exception.
Therefore I simply added a check whether `site.config['lang']` is defined before and this way everything works as expected.

I hope it helps others, too.

<details>
  <summary>Error Stacktrace (click to expand)</summary>

```

~/some_site ❯❯❯ bundle exec jekyll doctor
Configuration file: /home/user/some_site/_config.yml
Configuration file: /home/user/some_site/_config.yml
jekyll 3.8.7 | Error:  no implicit conversion of nil into String
Traceback (most recent call last):
  44: from /home/user/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
  43: from /home/user/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
  42: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
  41: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
  40: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
  39: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
  38: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
  37: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
  36: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
  35: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  34: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  33: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
  32: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
  31: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
  30: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
  29: from /home/user/.rbenv/versions/2.7.1/bin/jekyll:23:in `<top (required)>'
  28: from /home/user/.rbenv/versions/2.7.1/bin/jekyll:23:in `load'
  27: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/exe/jekyll:15:in `<top (required)>'
  26: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
  25: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
  24: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
  23: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
  22: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
  21: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/commands/doctor.rb:17:in `block (2 levels) in init_with_program'
  20: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/commands/doctor.rb:26:in `process'
  19: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:173:in `generate'
  18: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:173:in `each'
  17: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:175:in `block in generate'
  16: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-redirect-from-0.15.0/lib/jekyll-redirect-from/generator.rb:18:in `generate'
  15: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-redirect-from-0.15.0/lib/jekyll-redirect-from/generator.rb:18:in `each'
  14: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-redirect-from-0.15.0/lib/jekyll-redirect-from/generator.rb:21:in `block in generate'
  13: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-redirect-from-0.15.0/lib/jekyll-redirect-from/generator.rb:32:in `generate_redirect_from'
  12: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-redirect-from-0.15.0/lib/jekyll-redirect-from/redirectable.rb:20:in `redirect_from'
  11: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/convertible.rb:115:in `to_liquid'
  10: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/convertible.rb:115:in `map'
   9: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/convertible.rb:116:in `block in to_liquid'
   8: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/page.rb:67:in `dir'
   7: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/page.rb:101:in `url'
   6: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/page.rb:87:in `template'
   5: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/page.rb:171:in `html?'
   4: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/convertible.rb:89:in `output_ext'
   3: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/renderer.rb:45:in `output_ext'
   2: from /home/user/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/jekyll-3.8.7/lib/jekyll/renderer.rb:250:in `permalink_ext'
   1: from /path/to/gems/jekyll-multiple-languages-plugin/lib/jekyll-multiple-languages-plugin.rb:248:in `permalink'
/path/to/gems/jekyll-multiple-languages-plugin/lib/jekyll-multiple-languages-plugin.rb:248:in `+': no implicit conversion of nil into String (TypeError)

```


</details>

**PS:** Thank you for the `jekyll-multiple-languages-plugin`! It's great!