### PR TITLE
Update README.md to fix typo in the "Select pages translations" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Example:
 permalink:      /team/
 permalink_fr:   /equipe/
 
-langauges: ["fr"]
+languages: ["fr"]
 ---
 ```
 


### PR DESCRIPTION
Sorry for the minuscule PR, I was reading the README and noticed the typo.
The tag `languages` was misspelled as `langauges` in the example.