### PR TITLE
Support empty languages

### DIFF
--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -379,7 +379,9 @@ module Jekyll
       
       lang = site.config['lang']
       
-      translation = site.parsed_translations[lang].access(key) if key.is_a?(String)
+      if site.parsed_translations[lang]
+        translation = site.parsed_translations[lang].access(key) if key.is_a?(String)
+      end
       
       if translation.nil? or translation.empty?
          translation = site.parsed_translations[site.config['default_lang']].access(key)


### PR DESCRIPTION
Now if one of the languages has an empty yml, it will raise an error 

```
undefined method `access' for false:FalseClass (NoMethodError)
```

With this pull request, it will just ignore it and take the default language

Useful when you want to support a language but didn't start translating it yet